### PR TITLE
Add transparent styling options for China Unicom widgets

### DIFF
--- a/Scripting/Source/中國聯通/index.tsx
+++ b/Scripting/Source/中國聯通/index.tsx
@@ -113,6 +113,10 @@ const defaultSettings: ChinaUnicomSettings = {
 
   // ✅ 仅作用于紧凑/进度清单：2行/3行
   smallMiniBarUseTotalFlow: false,
+
+  // 透明样式
+  useTransparentStyle: false,
+  useTintBorderOnTransparent: false,
 }
 
 // ==================== 设置页面 ====================
@@ -180,6 +184,13 @@ function SettingsView() {
   const [smallMiniBarUseTotalFlow, setSmallMiniBarUseTotalFlow] =
     useState<boolean>(initial.smallMiniBarUseTotalFlow ?? false)
 
+  // 透明样式
+  const [useTransparentStyle, setUseTransparentStyle] = useState<boolean>(
+    initial.useTransparentStyle ?? false,
+  )
+  const [useTintBorderOnTransparent, setUseTintBorderOnTransparent] =
+    useState<boolean>(initial.useTintBorderOnTransparent ?? false)
+
   const currentMatchType: "flowType" | "addupItemCode" =
     MATCH_TYPE_OPTIONS[matchTypeIndex]?.value ?? "flowType"
 
@@ -206,6 +217,9 @@ function SettingsView() {
 
       smallCardStyle,
       smallMiniBarUseTotalFlow: !!smallMiniBarUseTotalFlow,
+
+      useTransparentStyle: !!useTransparentStyle,
+      useTintBorderOnTransparent: !!useTintBorderOnTransparent,
     }
 
     Storage.set(SETTINGS_KEY, newSettings)
@@ -309,6 +323,10 @@ function SettingsView() {
           setIncludeDirectionalInTotal={setIncludeDirectionalInTotal}
           refreshInterval={refreshInterval}
           setRefreshInterval={setRefreshInterval}
+          useTransparentStyle={useTransparentStyle}
+          setUseTransparentStyle={setUseTransparentStyle}
+          useTintBorderOnTransparent={useTintBorderOnTransparent}
+          setUseTintBorderOnTransparent={setUseTintBorderOnTransparent}
         />
 
         {/* 定向流量配置 */}

--- a/Scripting/Source/中國聯通/telecom/cards/components/dialRingStatCard.tsx
+++ b/Scripting/Source/中國聯通/telecom/cards/components/dialRingStatCard.tsx
@@ -3,6 +3,7 @@
 import { VStack, Text, Image, Spacer, ZStack, Gauge } from "scripting"
 import { RingCardTheme, timeStyle } from "../../theme"
 import { clamp01, percentText } from "../../utils/telecomUtils"
+import { buildCardBackground, wrapWithOutline, defaultVisualStyle, VisualStyleConfig } from "../../visualStyle"
 
 const Empty = <Text font={1}> </Text>
 
@@ -16,19 +17,22 @@ export function DialRingStatCard(props: {
   valueText: string
   theme: RingCardTheme
   ratio?: number
+  visualStyle?: VisualStyleConfig
 }) {
   const { title, valueText, theme, ratio } = props
+  const visualStyle = props.visualStyle ?? defaultVisualStyle
   const r = clamp01(ratio ?? 0)
 
-  return (
+  const card = (
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 8, bottom: 10, trailing: 8 }}
       frame={{ minWidth: 0, maxWidth: Infinity }}
-      widgetBackground={{
-        style: theme.bg,
-        shape: { type: "rect", cornerRadius: 18, style: "continuous" },
-      }}
+      widgetBackground={buildCardBackground({
+        visual: visualStyle,
+        base: theme.bg,
+        cornerRadius: 18,
+      })}
     >
       <Spacer minLength={2} />
       <ZStack frame={{ width: 56, height: 56 }}>
@@ -83,4 +87,10 @@ export function DialRingStatCard(props: {
       <Spacer minLength={4} />
     </VStack>
   )
+
+  return wrapWithOutline(card, {
+    visual: visualStyle,
+    tint: theme.tint,
+    cornerRadius: 18,
+  })
 }

--- a/Scripting/Source/中國聯通/telecom/cards/components/feeCard.tsx
+++ b/Scripting/Source/中國聯通/telecom/cards/components/feeCard.tsx
@@ -7,6 +7,7 @@ import {
   Spacer,
 } from "scripting"
 import { timeStyle, RingCardTheme } from "../../theme"
+import { buildCardBackground, wrapWithOutline, defaultVisualStyle, VisualStyleConfig } from "../../visualStyle"
 
 export function FeeCard(props: {
   title: string
@@ -14,8 +15,10 @@ export function FeeCard(props: {
   theme: RingCardTheme
   logoPath?: string | null
   updateTime: string
+  visualStyle?: VisualStyleConfig
 }) {
   const { title, valueText, theme, logoPath, updateTime } = props
+  const visualStyle = props.visualStyle ?? defaultVisualStyle
   const isUrlLogo =
     !!logoPath && (logoPath.startsWith("http://") || logoPath.startsWith("https://"))
 
@@ -35,15 +38,16 @@ export function FeeCard(props: {
       />
     )
 
-  return (
+  const card = (
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 10, bottom: 10, trailing: 10 }}
       frame={{ minWidth: 0, maxWidth: Infinity }}
-      widgetBackground={{
-        style: theme.bg,
-        shape: { type: "rect", cornerRadius: 18, style: "continuous" },
-      }}
+      widgetBackground={buildCardBackground({
+        visual: visualStyle,
+        base: theme.bg,
+        cornerRadius: 18,
+      })}
     >
       <Spacer minLength={2} />
       <HStack alignment="center">
@@ -94,4 +98,10 @@ export function FeeCard(props: {
       <Spacer minLength={4} />
     </VStack>
   )
+
+  return wrapWithOutline(card, {
+    visual: visualStyle,
+    tint: theme.tint,
+    cornerRadius: 18,
+  })
 }

--- a/Scripting/Source/中國聯通/telecom/cards/components/fullRingStatCard.tsx
+++ b/Scripting/Source/中國聯通/telecom/cards/components/fullRingStatCard.tsx
@@ -3,6 +3,7 @@
 import { VStack, Text, Image, Spacer, ZStack, Gauge } from "scripting"
 import { RingCardTheme, timeStyle } from "../../theme"
 import { clamp01, percentText } from "../../utils/telecomUtils"
+import { buildCardBackground, wrapWithOutline, defaultVisualStyle, VisualStyleConfig } from "../../visualStyle"
 
 /**
  * FullRingStatCard（全圆环）
@@ -13,19 +14,22 @@ export function FullRingStatCard(props: {
   valueText: string
   theme: RingCardTheme
   ratio?: number
+  visualStyle?: VisualStyleConfig
 }) {
   const { title, valueText, theme, ratio } = props
+  const visualStyle = props.visualStyle ?? defaultVisualStyle
   const r = clamp01(ratio ?? 0)
 
-  return (
+  const card = (
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 8, bottom: 10, trailing: 8 }}
       frame={{ minWidth: 0, maxWidth: Infinity }}
-      widgetBackground={{
-        style: theme.bg,
-        shape: { type: "rect", cornerRadius: 18, style: "continuous" },
-      }}
+      widgetBackground={buildCardBackground({
+        visual: visualStyle,
+        base: theme.bg,
+        cornerRadius: 18,
+      })}
     >
       <Spacer minLength={2} />
       <ZStack frame={{ width: 56, height: 56 }}>
@@ -80,4 +84,10 @@ export function FullRingStatCard(props: {
       <Spacer minLength={4} />
     </VStack>
   )
+
+  return wrapWithOutline(card, {
+    visual: visualStyle,
+    tint: theme.tint,
+    cornerRadius: 18,
+  })
 }

--- a/Scripting/Source/中國聯通/telecom/cards/medium/common.tsx
+++ b/Scripting/Source/中國聯通/telecom/cards/medium/common.tsx
@@ -1,6 +1,7 @@
 // telecom/cards/medium/common.tsx
 import { VStack, HStack } from "scripting"
 import { outerCardBg } from "../../theme"
+import { buildCardBackground, wrapWithOutline, defaultVisualStyle, VisualStyleConfig } from "../../visualStyle"
 
 export type MediumStyleKey = "FullRing" | "DialRing"
 
@@ -21,22 +22,27 @@ export type MediumCommonProps = {
   voiceTitle: string
   voiceValueText: string
   voiceRatio: number
+
+  visualStyle?: VisualStyleConfig
 }
 
-export function MediumOuter(props: { children: any }) {
+export function MediumOuter(props: { children: any; visualStyle?: VisualStyleConfig }) {
   const { children } = props
-  return (
+  const visualStyle = props.visualStyle ?? defaultVisualStyle
+  return wrapWithOutline(
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 10, bottom: 10, trailing: 10 }}
-      widgetBackground={{
-        style: outerCardBg,
-        shape: { type: "rect", cornerRadius: 24, style: "continuous" },
-      }}
+      widgetBackground={buildCardBackground({
+        visual: visualStyle,
+        base: outerCardBg,
+        cornerRadius: 24,
+      })}
     >
       <HStack alignment="center" spacing={10}>
         {children}
       </HStack>
-    </VStack>
+    </VStack>,
+    { visual: visualStyle, cornerRadius: 24 },
   )
 }

--- a/Scripting/Source/中國聯通/telecom/cards/medium/styles/DialRingCardStyle.tsx
+++ b/Scripting/Source/中國聯通/telecom/cards/medium/styles/DialRingCardStyle.tsx
@@ -26,6 +26,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
     voiceTitle,
     voiceValueText,
     voiceRatio,
+    visualStyle,
   } = props
 
   const showOther =
@@ -33,13 +34,14 @@ export function DialRingCardStyle(props: MediumCommonProps) {
     (typeof otherValueText === "string" && otherValueText.trim().length > 0)
 
   return (
-    <MediumOuter>
+    <MediumOuter visualStyle={visualStyle}>
       <FeeCard
         title={feeTitle}
         valueText={feeText}
         theme={ringThemes.fee}
         logoPath={logoPath}
         updateTime={updateTime}
+        visualStyle={visualStyle}
       />
 
       <DialRingStatCard
@@ -47,6 +49,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
         valueText={flowValueText}
         theme={ringThemes.flow}
         ratio={flowRatio}
+        visualStyle={visualStyle}
       />
 
       {showOther ? (
@@ -56,6 +59,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
           valueText={otherValueText ?? "0MB"}
           theme={ringThemes.flowDir}
           ratio={otherRatio ?? 0}
+          visualStyle={visualStyle}
         />
       ) : null}
 
@@ -64,6 +68,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
         valueText={voiceValueText}
         theme={ringThemes.voice}
         ratio={voiceRatio}
+        visualStyle={visualStyle}
       />
     </MediumOuter>
   )

--- a/Scripting/Source/中國聯通/telecom/cards/medium/styles/FullRingCardStyle.tsx
+++ b/Scripting/Source/中國聯通/telecom/cards/medium/styles/FullRingCardStyle.tsx
@@ -25,6 +25,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
     voiceTitle,
     voiceValueText,
     voiceRatio,
+    visualStyle,
   } = props
 
   const showOther =
@@ -32,13 +33,14 @@ export function FullRingCardStyle(props: MediumCommonProps) {
     (typeof otherValueText === "string" && otherValueText.trim().length > 0)
 
   return (
-    <MediumOuter>
+    <MediumOuter visualStyle={visualStyle}>
       <FeeCard
         title={feeTitle}
         valueText={feeText}
         theme={ringThemes.fee}
         logoPath={logoPath}
         updateTime={updateTime}
+        visualStyle={visualStyle}
       />
 
       <FullRingStatCard
@@ -46,6 +48,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
         valueText={flowValueText}
         theme={ringThemes.flow}
         ratio={flowRatio}
+        visualStyle={visualStyle}
       />
 
       {showOther ? (
@@ -55,6 +58,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
           valueText={otherValueText ?? "0MB"}
           theme={ringThemes.flowDir}
           ratio={otherRatio ?? 0}
+          visualStyle={visualStyle}
         />
       ) : null}
 
@@ -63,6 +67,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
         valueText={voiceValueText}
         theme={ringThemes.voice}
         ratio={voiceRatio}
+        visualStyle={visualStyle}
       />
     </MediumOuter>
   )

--- a/Scripting/Source/中國聯通/telecom/cards/small/common.tsx
+++ b/Scripting/Source/中國聯通/telecom/cards/small/common.tsx
@@ -1,6 +1,7 @@
 // telecom/cards/small/common.tsx
 import { Text, Image } from "scripting"
 import { telecomRingThemes } from "../../theme"
+import type { VisualStyleConfig } from "../../visualStyle"
 
 /**
  * 小号组件通用 Props：
@@ -41,6 +42,9 @@ export type SmallCardCommonProps = {
 
   /** 仅作用于 CompactList / ProgressList：true=总流量+语音（2行），false=通用+定向+语音（3行） */
   smallMiniBarUseTotalFlow?: boolean
+
+  /** 视觉样式控制 */
+  visualStyle?: VisualStyleConfig
 }
 
 // ========= 小工具：Logo + 胶囊单位 =========

--- a/Scripting/Source/中國聯通/telecom/cards/small/smallCardStyles.tsx
+++ b/Scripting/Source/中國聯通/telecom/cards/small/smallCardStyles.tsx
@@ -4,6 +4,12 @@ import { VStack, HStack, ZStack, Text, Spacer, Image } from "scripting"
 import type { SmallCardCommonProps } from "./common"
 import { ringThemes, timeStyle } from "../../theme"
 import type { RingCardTheme } from "../../theme"
+import {
+  buildCardBackground,
+  wrapWithOutline,
+  defaultVisualStyle,
+  type VisualStyleConfig,
+} from "../../visualStyle"
 
 // =====================================================================
 // Layout Helpers · 强制“靠左”
@@ -32,15 +38,17 @@ function Right(props: { children: any }) {
 // SmallCardSurface · 外壳统一：systemBackground + 单一圆角（防露边）
 // 关键：外层不要 center；否则内部“块”容易被居中摆放
 // =====================================================================
-function SmallCardSurface(props: { children: any }) {
-  return (
+function SmallCardSurface(props: { children: any; visualStyle?: VisualStyleConfig }) {
+  const visualStyle = props.visualStyle ?? defaultVisualStyle
+  const card = (
     <VStack
       alignment="leading"
       padding={{ top: 6, leading: 8, bottom: 6, trailing: 8 }}
-      widgetBackground={{
-        style: "systemBackground",
-        shape: { type: "rect", cornerRadius: 26, style: "continuous" },
-      }}
+      widgetBackground={buildCardBackground({
+        visual: visualStyle,
+        base: "systemBackground",
+        cornerRadius: 26,
+      })}
       frame={{ minWidth: 0, maxWidth: Infinity, minHeight: 0, maxHeight: Infinity }}
     >
       <Spacer minLength={2} />
@@ -52,6 +60,8 @@ function SmallCardSurface(props: { children: any }) {
       <Spacer minLength={2} />
     </VStack>
   )
+
+  return wrapWithOutline(card, { visual: visualStyle, cornerRadius: 26 })
 }
 
 // =====================================================================
@@ -60,21 +70,26 @@ function SmallCardSurface(props: { children: any }) {
 function ContentCard(props: {
   children: any
   padding?: { top: number; leading: number; bottom: number; trailing: number }
+  visualStyle?: VisualStyleConfig
 }) {
   const pad = props.padding ?? { top: 6, leading: 10, bottom: 6, trailing: 10 }
-  return (
+  const visualStyle = props.visualStyle ?? defaultVisualStyle
+  const card = (
     <VStack
       alignment="leading"
       padding={pad}
       frame={{ minWidth: 0, maxWidth: Infinity }}
-      widgetBackground={{
-        style: { light: "rgba(0,0,0,0.04)", dark: "rgba(255,255,255,0.06)" } as any,
-        shape: { type: "rect", cornerRadius: 16, style: "continuous" },
-      }}
+      widgetBackground={buildCardBackground({
+        visual: visualStyle,
+        base: { light: "rgba(0,0,0,0.04)", dark: "rgba(255,255,255,0.06)" } as any,
+        cornerRadius: 16,
+      })}
     >
       {props.children}
     </VStack>
   )
+
+  return wrapWithOutline(card, { visual: visualStyle, cornerRadius: 16 })
 }
 
 // =====================================================================
@@ -85,24 +100,29 @@ function TintPanel(props: {
   cornerRadius?: number
   padding?: { top: number; leading: number; bottom: number; trailing: number }
   spacing?: number
+  visualStyle?: VisualStyleConfig
 }) {
   const r = props.cornerRadius ?? 16
   const pad = props.padding ?? { top: 8, leading: 10, bottom: 8, trailing: 10 }
   const sp = props.spacing ?? 6
-  return (
+  const visualStyle = props.visualStyle ?? defaultVisualStyle
+  const card = (
     <VStack
       spacing={sp}
       alignment="leading"
       padding={pad}
       frame={{ minWidth: 0, maxWidth: Infinity }}
-      widgetBackground={{
-        style: { light: "rgba(0,0,0,0.03)", dark: "rgba(255,255,255,0.07)" } as any,
-        shape: { type: "rect", cornerRadius: r, style: "continuous" },
-      }}
+      widgetBackground={buildCardBackground({
+        visual: visualStyle,
+        base: { light: "rgba(0,0,0,0.03)", dark: "rgba(255,255,255,0.07)" } as any,
+        cornerRadius: r,
+      })}
     >
       {props.children}
     </VStack>
   )
+
+  return wrapWithOutline(card, { visual: visualStyle, cornerRadius: r })
 }
 
 // =====================================================================
@@ -336,10 +356,15 @@ export const SMALL_STYLE_OPTIONS: Array<{ key: SmallStyleKey; nameCN: string; na
   { key: "TextList", nameCN: "文字清单", nameEN: "TextList" },
 ]
 
+function pickVisualStyle(props: SmallCardCommonProps): VisualStyleConfig {
+  return props.visualStyle ?? defaultVisualStyle
+}
+
 // =====================================================================
 // Style · CompactList（紧凑清单）
 // =====================================================================
 export function CompactListSmallStyle(props: SmallCardCommonProps) {
+  const visualStyle = pickVisualStyle(props)
   const fee = parseFeeText(props.feeText)
 
   const useTotal = !!props.smallMiniBarUseTotalFlow
@@ -377,7 +402,7 @@ export function CompactListSmallStyle(props: SmallCardCommonProps) {
   const voiceText = `${String(props.voiceValue ?? "0")}${String(props.voiceUnit ?? "") || "分钟"}`
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface visualStyle={visualStyle}>
       <VStack spacing={4} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
         <HStack alignment="top" spacing={6} frame={{ minWidth: 0, maxWidth: Infinity }}>
           <VStack spacing={2} alignment="leading" frame={{ minWidth: 0, maxWidth: Infinity }}>
@@ -412,10 +437,11 @@ export function CompactListSmallStyle(props: SmallCardCommonProps) {
           alignment="leading"
           padding={{ top: 7, leading: 10, bottom: 7, trailing: 10 }}
           spacing={showOther ? 7 : 8}
-          widgetBackground={{
-            style: { light: "rgba(0,0,0,0.06)", dark: "rgba(255,255,255,0.08)" } as any,
-            shape: { type: "rect", cornerRadius: 18, style: "continuous" },
-          }}
+          widgetBackground={buildCardBackground({
+            visual: visualStyle,
+            base: { light: "rgba(0,0,0,0.06)", dark: "rgba(255,255,255,0.08)" } as any,
+            cornerRadius: 18,
+          })}
           frame={{ minWidth: 0, maxWidth: Infinity }}
         >
           <NeoRow label={flowLabel} value={flowText} theme={ringThemes.flow} />
@@ -431,6 +457,7 @@ export function CompactListSmallStyle(props: SmallCardCommonProps) {
 // Style · ProgressList（进度清单）
 // =====================================================================
 export function ProgressListSmallStyle(props: SmallCardCommonProps) {
+  const visualStyle = pickVisualStyle(props)
   const fee = parseFeeText(props.feeText)
 
   const useTotal = !!props.smallMiniBarUseTotalFlow
@@ -443,7 +470,7 @@ export function ProgressListSmallStyle(props: SmallCardCommonProps) {
   const flowRatio = useTotal ? props.totalFlowRatio : props.flowRatio
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface visualStyle={visualStyle}>
       <VStack spacing={4} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
         <HStack alignment="top" spacing={6} frame={{ minWidth: 0, maxWidth: Infinity }}>
           <VStack spacing={2} alignment="leading" frame={{ minWidth: 0, maxWidth: Infinity }}>
@@ -478,10 +505,11 @@ export function ProgressListSmallStyle(props: SmallCardCommonProps) {
           alignment="leading"
           padding={{ top: 7, leading: 10, bottom: 7, trailing: 10 }}
           spacing={showOther ? 7 : 8}
-          widgetBackground={{
-            style: { light: "rgba(0,0,0,0.06)", dark: "rgba(255,255,255,0.08)" } as any,
-            shape: { type: "rect", cornerRadius: 18, style: "continuous" },
-          }}
+          widgetBackground={buildCardBackground({
+            visual: visualStyle,
+            base: { light: "rgba(0,0,0,0.06)", dark: "rgba(255,255,255,0.08)" } as any,
+            cornerRadius: 18,
+          })}
           frame={{ minWidth: 0, maxWidth: Infinity }}
         >
           <InfoRowWithBar
@@ -519,6 +547,7 @@ export function ProgressListSmallStyle(props: SmallCardCommonProps) {
 // Style · 三条信息卡
 // =====================================================================
 export function TripleRowsSmallStyle(props: SmallCardCommonProps) {
+  const visualStyle = pickVisualStyle(props)
   const fee = parseFeeText(props.feeText)
 
   const Row = (p: { theme: RingCardTheme; title: string; value: string; unit: string; rightLogo?: boolean }) => (
@@ -540,15 +569,15 @@ export function TripleRowsSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface visualStyle={visualStyle}>
       <VStack spacing={10} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard>
+        <ContentCard visualStyle={visualStyle}>
           <Row theme={ringThemes.fee} title={props.feeTitle || "剩余话费"} value={fee.balance} unit={fee.unit || "元"} rightLogo />
         </ContentCard>
-        <ContentCard>
+        <ContentCard visualStyle={visualStyle}>
           <Row theme={ringThemes.flow} title={props.flowLabel || "剩余流量"} value={String(props.flowValue ?? "0")} unit={String(props.flowUnit ?? "")} />
         </ContentCard>
-        <ContentCard>
+        <ContentCard visualStyle={visualStyle}>
           <Row theme={ringThemes.voice} title={props.voiceLabel || "剩余语音"} value={String(props.voiceValue ?? "0")} unit={String(props.voiceUnit ?? "") || "分钟"} />
         </ContentCard>
       </VStack>
@@ -560,6 +589,7 @@ export function TripleRowsSmallStyle(props: SmallCardCommonProps) {
 // Style · 圆标信息卡
 // =====================================================================
 export function IconCellsSmallStyle(props: SmallCardCommonProps) {
+  const visualStyle = pickVisualStyle(props)
   const fee = parseFeeText(props.feeText)
 
   const Cell = (p: { theme: RingCardTheme; title: string; value: string; unit: string; leftLogo?: boolean }) => (
@@ -590,17 +620,17 @@ export function IconCellsSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface visualStyle={visualStyle}>
       <VStack spacing={4} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
+        <ContentCard visualStyle={visualStyle} padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
           <Cell theme={ringThemes.fee} title={props.feeTitle || "剩余话费"} value={fee.balance} unit={fee.unit || "元"} leftLogo />
         </ContentCard>
 
-        <ContentCard padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
+        <ContentCard visualStyle={visualStyle} padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
           <Cell theme={ringThemes.flow} title={props.flowLabel || "剩余流量"} value={String(props.flowValue ?? "0")} unit={String(props.flowUnit ?? "")} />
         </ContentCard>
 
-        <ContentCard padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
+        <ContentCard visualStyle={visualStyle} padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
           <Cell theme={ringThemes.voice} title={props.voiceLabel || "剩余语音"} value={String(props.voiceValue ?? "0")} unit={String(props.voiceUnit ?? "") || "分钟"} />
         </ContentCard>
       </VStack>
@@ -612,6 +642,7 @@ export function IconCellsSmallStyle(props: SmallCardCommonProps) {
 // Style · 余额主卡 + 下两块
 // =====================================================================
 export function BalanceFocusSmallStyle(props: SmallCardCommonProps) {
+  const visualStyle = pickVisualStyle(props)
   const fee = parseFeeText(props.feeText)
 
   const BLOCK_W = 80
@@ -623,7 +654,7 @@ export function BalanceFocusSmallStyle(props: SmallCardCommonProps) {
 
   const MiniBlock = (p: { theme: RingCardTheme; label: string; value: string }) => (
     <VStack frame={{ width: BLOCK_W }}>
-      <ContentCard padding={{ top: 6, leading: 6, bottom: 6, trailing: 6 }}>
+      <ContentCard visualStyle={visualStyle} padding={{ top: 6, leading: 6, bottom: 6, trailing: 6 }}>
         <VStack spacing={4} alignment="center" frame={{ width: BLOCK_W - 12, height: BLOCK_H }}>
           <SymbolImage systemName={p.theme.icon} size={16} tint={p.theme.tint} opacity={0.9} />
           <Text font={9} foregroundStyle={timeStyle} lineLimit={1} minScaleFactor={0.7}>
@@ -638,9 +669,9 @@ export function BalanceFocusSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface visualStyle={visualStyle}>
       <VStack spacing={0} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard padding={{ top: 7, leading: 8, bottom: 4, trailing: 8 }}>
+        <ContentCard visualStyle={visualStyle} padding={{ top: 7, leading: 8, bottom: 4, trailing: 8 }}>
           <VStack frame={{ minWidth: 0, maxWidth: Infinity, height: TOP_MIN_H }} alignment="leading">
             <HStack alignment="center" spacing={8} frame={{ minWidth: 0, maxWidth: Infinity }}>
               <VStack spacing={2} alignment="leading" frame={{ minWidth: 0, maxWidth: Infinity }}>
@@ -690,6 +721,7 @@ export function BalanceFocusSmallStyle(props: SmallCardCommonProps) {
 // Style · 上余额下列表
 // =====================================================================
 export function DualListSmallStyle(props: SmallCardCommonProps) {
+  const visualStyle = pickVisualStyle(props)
   const fee = parseFeeText(props.feeText)
   const showOther = !!(props.otherFlowLabel && String(props.otherFlowLabel).trim().length > 0)
 
@@ -701,9 +733,9 @@ export function DualListSmallStyle(props: SmallCardCommonProps) {
   const otherUnitText = String(props.otherFlowUnit ?? "GB").toUpperCase()
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface visualStyle={visualStyle}>
       <VStack spacing={10} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard>
+        <ContentCard visualStyle={visualStyle}>
           <HStack alignment="top" spacing={6} frame={{ minWidth: 0, maxWidth: Infinity }}>
             <VStack spacing={2} alignment="leading" frame={{ minWidth: 0, maxWidth: Infinity }}>
               <Left>
@@ -734,7 +766,7 @@ export function DualListSmallStyle(props: SmallCardCommonProps) {
           </HStack>
         </ContentCard>
 
-        <TintPanel spacing={showOther ? 6 : 7} cornerRadius={16}>
+        <TintPanel visualStyle={visualStyle} spacing={showOther ? 6 : 7} cornerRadius={16}>
           <ListRow theme={ringThemes.flow} label={props.flowLabel || "剩余流量"} valueText={flowValueText} unitText={flowUnitText} />
           {showOther ? (
             <ListRow theme={ringThemes.flowDir} label={String(props.otherFlowLabel)} valueText={otherValueText} unitText={otherUnitText} />
@@ -750,6 +782,7 @@ export function DualListSmallStyle(props: SmallCardCommonProps) {
 // Style · 双环仪表（保持原样）
 // =====================================================================
 export function DualGaugesSmallStyle(props: SmallCardCommonProps) {
+  const visualStyle = pickVisualStyle(props)
   const fee = parseFeeText(props.feeText)
 
   const Ring = (p: { theme: RingCardTheme; title: string; value: string; unit: string }) => (
@@ -789,9 +822,9 @@ export function DualGaugesSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface visualStyle={visualStyle}>
       <VStack spacing={10} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard>
+        <ContentCard visualStyle={visualStyle}>
           <HStack alignment="center" spacing={6} frame={{ minWidth: 0, maxWidth: Infinity }}>
             <Spacer />
             <LogoImage logoPath={props.logoPath} size={34} fallbackTheme={ringThemes.fee} />
@@ -837,6 +870,7 @@ export function DualGaugesSmallStyle(props: SmallCardCommonProps) {
 // Style · 文字清单
 // =====================================================================
 export function TextListSmallStyle(props: SmallCardCommonProps) {
+  const visualStyle = pickVisualStyle(props)
   const fee = parseFeeText(props.feeText)
   const showOther = !!(props.otherFlowLabel && String(props.otherFlowLabel).trim().length > 0)
 
@@ -855,9 +889,9 @@ export function TextListSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface visualStyle={visualStyle}>
       <VStack spacing={10} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard>
+        <ContentCard visualStyle={visualStyle}>
           <HStack alignment="center" spacing={8} frame={{ minWidth: 0, maxWidth: Infinity }}>
             <LogoImage logoPath={props.logoPath} size={22} fallbackTheme={ringThemes.fee} />
             <Spacer />

--- a/Scripting/Source/中國聯通/telecom/cards/small/summaryCardStyle.tsx
+++ b/Scripting/Source/中國聯通/telecom/cards/small/summaryCardStyle.tsx
@@ -4,15 +4,22 @@ import { VStack, Spacer } from "scripting"
 import type { SmallCardCommonProps } from "./common"
 import { FeeCard } from "../components/feeCard"
 import { ringThemes } from "../../theme"
+import { buildCardBackground, wrapWithOutline, defaultVisualStyle } from "../../visualStyle"
 
 // summary 样式：直接用 FeeCard 缩小版，只展示话费卡（垂直居中）
 export function TelecomSmallSummaryCard(props: SmallCardCommonProps) {
   const { feeTitle, feeText, logoPath, updateTime } = props
+  const visualStyle = props.visualStyle ?? defaultVisualStyle
 
-  return (
+  const content = (
     <VStack
       alignment="center"
       padding={{ top: 4, leading: 4, bottom: 4, trailing: 4 }}
+      widgetBackground={buildCardBackground({
+        visual: visualStyle,
+        base: "systemBackground",
+        cornerRadius: 24,
+      })}
     >
       <Spacer />
       <FeeCard
@@ -21,8 +28,11 @@ export function TelecomSmallSummaryCard(props: SmallCardCommonProps) {
         theme={ringThemes.fee}
         logoPath={logoPath}
         updateTime={updateTime ?? ""}
+        visualStyle={visualStyle}
       />
       <Spacer />
     </VStack>
   )
+
+  return wrapWithOutline(content, { visual: visualStyle, cornerRadius: 24 })
 }

--- a/Scripting/Source/中國聯通/telecom/index/renderConfigSection.tsx
+++ b/Scripting/Source/中國聯通/telecom/index/renderConfigSection.tsx
@@ -31,6 +31,11 @@ type RenderConfigSectionProps = {
 
   refreshInterval: number
   setRefreshInterval: (v: number) => void
+
+  useTransparentStyle: boolean
+  setUseTransparentStyle: (v: boolean) => void
+  useTintBorderOnTransparent: boolean
+  setUseTintBorderOnTransparent: (v: boolean) => void
 }
 
 const REFRESH_OPTIONS = [
@@ -78,6 +83,11 @@ export function RenderConfigSection(props: RenderConfigSectionProps) {
 
     refreshInterval,
     setRefreshInterval,
+
+    useTransparentStyle,
+    setUseTransparentStyle,
+    useTintBorderOnTransparent,
+    setUseTintBorderOnTransparent,
   } = props
 
   // ✅ 只对 CompactList / ProgressList 生效的联动开关（保持原逻辑不动）
@@ -107,6 +117,24 @@ export function RenderConfigSection(props: RenderConfigSectionProps) {
         value={showRemainRatio}
         onChanged={setShowRemainRatio}
       />
+
+      <Toggle
+        title={useTransparentStyle ? "透明样式：已开启" : "透明样式：已关闭"}
+        value={useTransparentStyle}
+        onChanged={setUseTransparentStyle}
+      />
+
+      {useTransparentStyle ? (
+        <Toggle
+          title={
+            useTintBorderOnTransparent
+              ? "透明样式：显示彩色线条边框"
+              : "透明样式：不显示彩色线条边框"
+          }
+          value={useTintBorderOnTransparent}
+          onChanged={setUseTintBorderOnTransparent}
+        />
+      ) : null}
 
       {/* ==================== 小号 ==================== */}
       <Picker

--- a/Scripting/Source/中國聯通/telecom/settings.ts
+++ b/Scripting/Source/中國聯通/telecom/settings.ts
@@ -12,6 +12,12 @@ export type MediumCardLayout = "three" | "four"
 export type UiSettings = {
   showRemainRatio: boolean
 
+  /** 是否渲染透明样式 */
+  useTransparentStyle: boolean
+
+  /** 透明样式下是否启用彩色线条边框 */
+  useTintBorderOnTransparent: boolean
+
   /** 中号样式：全圆环 / 仪表盘 */
   mediumStyle: MediumStyleKey
 
@@ -55,6 +61,10 @@ export type UiSwitchSource = Partial<UiSettings> & {
 
   // ✅ 新字段：给配置页做开关用
   mediumUseThreeLayout?: boolean
+
+  // ✅ 新字段：透明样式
+  useTransparentStyle?: boolean
+  useTintBorderOnTransparent?: boolean
 }
 
 // ==================== Operator Settings ====================
@@ -155,6 +165,9 @@ export function pickUiSettings(
 
   return {
     showRemainRatio: !!src.showRemainRatio,
+
+    useTransparentStyle: !!src.useTransparentStyle,
+    useTintBorderOnTransparent: !!src.useTintBorderOnTransparent,
 
     mediumStyle: normalizeMediumStyle((src as any).mediumStyle),
 

--- a/Scripting/Source/中國聯通/telecom/visualStyle.tsx
+++ b/Scripting/Source/中國聯通/telecom/visualStyle.tsx
@@ -1,0 +1,68 @@
+import { VStack } from "scripting"
+import type { DynamicShapeStyle } from "scripting"
+
+export type VisualStyleConfig = {
+  /** 是否渲染透明样式 */
+  useTransparentStyle: boolean
+  /** 透明样式下是否启用彩色线条边框 */
+  useTintBorderOnTransparent: boolean
+}
+
+export const defaultVisualStyle: VisualStyleConfig = {
+  useTransparentStyle: false,
+  useTintBorderOnTransparent: false,
+}
+
+const transparentSurface: DynamicShapeStyle = {
+  light: "rgba(255,255,255,0.02)",
+  dark: "rgba(0,0,0,0.10)",
+}
+
+const neutralBorder: DynamicShapeStyle = {
+  light: "rgba(255,255,255,0.26)",
+  dark: "rgba(255,255,255,0.35)",
+}
+
+export function buildCardBackground({
+  visual,
+  base,
+  cornerRadius,
+}: {
+  visual: VisualStyleConfig
+  base: DynamicShapeStyle | string
+  cornerRadius: number
+}) {
+  if (!visual.useTransparentStyle) {
+    return { style: base, shape: { type: "rect", cornerRadius, style: "continuous" } }
+  }
+
+  return {
+    style: transparentSurface,
+    shape: { type: "rect", cornerRadius, style: "continuous" },
+  }
+}
+
+export function wrapWithOutline(
+  children: any,
+  {
+    visual,
+    tint,
+    cornerRadius,
+  }: { visual: VisualStyleConfig; tint?: DynamicShapeStyle; cornerRadius: number },
+) {
+  if (!visual.useTransparentStyle || !visual.useTintBorderOnTransparent) {
+    return children
+  }
+
+  return (
+    <VStack
+      padding={{ top: 1, leading: 1, bottom: 1, trailing: 1 }}
+      widgetBackground={{
+        style: tint ?? neutralBorder,
+        shape: { type: "rect", cornerRadius: cornerRadius + 2, style: "continuous" },
+      }}
+    >
+      {children}
+    </VStack>
+  )
+}

--- a/Scripting/Source/中國聯通/telecom/widgetRoot.tsx
+++ b/Scripting/Source/中國聯通/telecom/widgetRoot.tsx
@@ -5,6 +5,7 @@ import { outerCardBg, ringThemes } from "./theme"
 import { buildUsageStat, formatFlowValue } from "./utils/telecomUtils"
 import type { UiSettings } from "./settings"
 import { loadUiSettings } from "./settings"
+import { buildCardBackground, VisualStyleConfig, wrapWithOutline } from "./visualStyle"
 
 import { MediumLayout } from "./cards/medium"
 import { FeeCard } from "./cards/components/feeCard"
@@ -41,7 +42,15 @@ export function WidgetRoot(props: {
 
     smallCardStyle,
     smallMiniBarUseTotalFlow,
+
+    useTransparentStyle,
+    useTintBorderOnTransparent,
   } = ui
+
+  const visualStyle: VisualStyleConfig = {
+    useTransparentStyle,
+    useTintBorderOnTransparent,
+  }
 
   // ✅ 新结构：用布局决定“是否走总流量三卡”
   const useTotalFlow = mediumUseThreeLayout
@@ -137,6 +146,7 @@ export function WidgetRoot(props: {
         feeText={`${data.fee.balance}${data.fee.unit}`}
         logoPath={logoPath}
         updateTime={data.updateTime}
+        visualStyle={visualStyle}
 
         // summary 用
         totalFlowLabel={summaryTotalFlowLabel}
@@ -177,6 +187,7 @@ export function WidgetRoot(props: {
         feeText={`${data.fee.balance}${data.fee.unit}`}
         logoPath={logoPath}
         updateTime={data.updateTime}
+        visualStyle={visualStyle}
 
         // 三卡：这里切总流量；四卡：这里切通用
         flowTitle={useTotalFlow ? totalFlowTitle : flowTitle}
@@ -197,14 +208,16 @@ export function WidgetRoot(props: {
 
   // ===== 大号：四格 RingCard =====
   return (
-    <VStack
-      alignment="center"
-      padding={{ top: 10, leading: 10, bottom: 10, trailing: 10 }}
-      widgetBackground={{
-        style: outerCardBg,
-        shape: { type: "rect", cornerRadius: 24, style: "continuous" },
-      }}
-    >
+    {wrapWithOutline(
+      <VStack
+        alignment="center"
+        padding={{ top: 10, leading: 10, bottom: 10, trailing: 10 }}
+        widgetBackground={buildCardBackground({
+          visual: visualStyle,
+          base: outerCardBg,
+          cornerRadius: 24,
+        })}
+      >
       <HStack alignment="center" spacing={10}>
         <FeeCard
           title={data.fee.title}
@@ -235,6 +248,8 @@ export function WidgetRoot(props: {
           ratio={voiceStat.ratio}
         />
       </HStack>
-    </VStack>
+      </VStack>,
+      { visual: visualStyle, cornerRadius: 24 },
+    )}
   )
 }


### PR DESCRIPTION
## Summary
- add configuration toggles for transparent styling and optional tinted outlines
- apply visual style helpers across China Unicom widget layouts to keep functionality while enabling clearer, reusable styling
- persist new settings through the UI and widget rendering pipeline

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947d512c3fc83268b41d74977aa4d53)