### PR TITLE
Add transparent widget style options

### DIFF
--- a/Scripting/Source/中國聯通/index.tsx
+++ b/Scripting/Source/中國聯通/index.tsx
@@ -192,6 +192,16 @@ function SettingsView() {
       ? initial.smallMiniBarUseTotalFlow
       : !!defaultChinaUnicomSettings.smallMiniBarUseTotalFlow
 
+  const initialTransparentStyle =
+    typeof initial.transparentWidgetStyle === "boolean"
+      ? initial.transparentWidgetStyle
+      : !!defaultChinaUnicomSettings.transparentWidgetStyle
+
+  const initialColorfulBorder =
+    typeof initial.colorfulLineBorder === "boolean"
+      ? initial.colorfulLineBorder
+      : !!defaultChinaUnicomSettings.colorfulLineBorder
+
   const initialCacheScopeKey = String(initial.cacheScopeKey ?? defaultChinaUnicomSettings.cacheScopeKey ?? "")
 
   const initialCache = (initial.cache ?? defaultChinaUnicomSettings.cache) as CacheConfig
@@ -227,6 +237,8 @@ function SettingsView() {
   const [smallMiniBarUseTotalFlow, setSmallMiniBarUseTotalFlow] = useState<boolean>(
     initialSmallMiniBarUseTotalFlow,
   )
+  const [transparentWidgetStyle, setTransparentWidgetStyle] = useState<boolean>(initialTransparentStyle)
+  const [colorfulLineBorder, setColorfulLineBorder] = useState<boolean>(initialColorfulBorder)
 
   const [cacheScopeKey, setCacheScopeKey] = useState<string>(initialCacheScopeKey)
   const [cacheDraft, setCacheDraft] = useState<CacheConfig>(initialCache)
@@ -279,6 +291,9 @@ function SettingsView() {
       mediumStyle,
       mediumUseThreeCard: !!mediumUseThreeCard,
       includeDirectionalInTotal: !!includeDirectionalInTotal,
+
+      transparentWidgetStyle: !!transparentWidgetStyle,
+      colorfulLineBorder: !!colorfulLineBorder,
 
       smallCardStyle,
       smallMiniBarUseTotalFlow: !!smallMiniBarUseTotalFlow,
@@ -377,6 +392,10 @@ function SettingsView() {
           setSmallCardStyle={setSmallCardStyle}
           showRemainRatio={showRemainRatio}
           setShowRemainRatio={setShowRemainRatio}
+          transparentWidgetStyle={transparentWidgetStyle}
+          setTransparentWidgetStyle={setTransparentWidgetStyle}
+          colorfulLineBorder={colorfulLineBorder}
+          setColorfulLineBorder={setColorfulLineBorder}
           smallMiniBarUseTotalFlow={smallMiniBarUseTotalFlow}
           setSmallMiniBarUseTotalFlow={setSmallMiniBarUseTotalFlow}
           mediumStyle={mediumStyle}

--- a/Scripting/Source/中國聯通/shared/carrier/cards/medium/common.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/medium/common.tsx
@@ -1,6 +1,7 @@
 // shared/carrier/cards/medium/common.tsx
 import { VStack, HStack } from "scripting"
 import { outerCardBg } from "../../theme"
+import { type WidgetSurfacePalette, DEFAULT_WIDGET_SURFACES } from "../../surfaces"
 
 export type MediumStyleKey = "FullRing" | "DialRing"
 
@@ -21,22 +22,38 @@ export type MediumCommonProps = {
   voiceTitle: string
   voiceValueText: string
   voiceRatio: number
+
+  surfaces?: WidgetSurfacePalette
 }
 
-export function MediumOuter(props: { children: any }) {
-  const { children } = props
-  return (
+export function MediumOuter(props: { children: any; surfaces?: WidgetSurfacePalette }) {
+  const surfaces = props.surfaces ?? DEFAULT_WIDGET_SURFACES
+  const body = (
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 10, bottom: 10, trailing: 10 }}
       widgetBackground={{
-        style: outerCardBg,
+        style: surfaces.outer || outerCardBg,
         shape: { type: "rect", cornerRadius: 24, style: "continuous" },
       }}
     >
       <HStack alignment="center" spacing={10}>
-        {children}
+        {props.children}
       </HStack>
+    </VStack>
+  )
+
+  if (!surfaces.border) return body
+
+  return (
+    <VStack
+      padding={{ top: 2, leading: 2, bottom: 2, trailing: 2 }}
+      widgetBackground={{
+        style: surfaces.border,
+        shape: { type: "rect", cornerRadius: 26, style: "continuous" },
+      }}
+    >
+      {body}
     </VStack>
   )
 }

--- a/Scripting/Source/中國聯通/shared/carrier/cards/medium/styles/DialRingCardStyle.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/medium/styles/DialRingCardStyle.tsx
@@ -33,7 +33,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
     (typeof otherValueText === "string" && otherValueText.trim().length > 0)
 
   return (
-    <MediumOuter>
+    <MediumOuter surfaces={props.surfaces}>
       <FeeCard
         title={feeTitle}
         valueText={feeText}

--- a/Scripting/Source/中國聯通/shared/carrier/cards/medium/styles/FullRingCardStyle.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/medium/styles/FullRingCardStyle.tsx
@@ -32,7 +32,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
     (typeof otherValueText === "string" && otherValueText.trim().length > 0)
 
   return (
-    <MediumOuter>
+    <MediumOuter surfaces={props.surfaces}>
       <FeeCard
         title={feeTitle}
         valueText={feeText}

--- a/Scripting/Source/中國聯通/shared/carrier/cards/small/common.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/small/common.tsx
@@ -1,6 +1,7 @@
 // shared/carrier/cards/small/common.tsx
 import { Text, Image } from "scripting"
 import { ringThemes } from "../../theme"
+import { type WidgetSurfacePalette, DEFAULT_WIDGET_SURFACES } from "../../surfaces"
 
 /**
  * 小号组件通用 Props：
@@ -41,6 +42,9 @@ export type SmallCardCommonProps = {
 
   /** 仅作用于 CompactList / ProgressList：true=总流量+语音（2行），false=通用+定向+语音（3行） */
   smallMiniBarUseTotalFlow?: boolean
+
+  /** Widget 外观：透明/描边等样式由上层传入；不传则使用默认不透明外观 */
+  surfaces?: WidgetSurfacePalette
 }
 
 // ========= 小工具：Logo + 胶囊单位 =========
@@ -78,14 +82,15 @@ export function LogoImage(props: { logoPath: string; size?: number }) {
   )
 }
 
-export function UnitPill(props: { text: string }) {
+export function UnitPill(props: { text: string; surfaces?: WidgetSurfacePalette }) {
+  const surfaces = props?.surfaces ?? DEFAULT_WIDGET_SURFACES
   return (
     <Text
       font={9}
       fontWeight="semibold"
       padding={{ top: 2, leading: 8, bottom: 2, trailing: 8 }}
       widgetBackground={{
-        style: "systemGray5",
+        style: surfaces.pill,
         shape: { type: "capsule", style: "continuous" },
       }}
     >

--- a/Scripting/Source/中國聯通/shared/carrier/cards/small/smallCardStyles.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/small/smallCardStyles.tsx
@@ -4,6 +4,7 @@ import { VStack, HStack, ZStack, Text, Spacer, Image } from "scripting"
 import type { SmallCardCommonProps } from "./common"
 import { ringThemes, timeStyle } from "../../theme"
 import type { RingCardTheme } from "../../theme"
+import { DEFAULT_WIDGET_SURFACES, type WidgetSurfacePalette } from "../../surfaces"
 
 // =====================================================================
 // Layout Helpers · 强制“靠左”
@@ -32,13 +33,14 @@ function Right(props: { children: any }) {
 // SmallCardSurface · 外壳统一：systemBackground + 单一圆角（防露边）
 // 关键：外层不要 center；否则内部“块”容易被居中摆放
 // =====================================================================
-function SmallCardSurface(props: { children: any }) {
-  return (
+export function SmallCardSurface(props: { children: any; surfaces?: WidgetSurfacePalette }) {
+  const surfaces = props.surfaces ?? DEFAULT_WIDGET_SURFACES
+  const body = (
     <VStack
       alignment="leading"
       padding={{ top: 6, leading: 8, bottom: 6, trailing: 8 }}
       widgetBackground={{
-        style: "systemBackground",
+        style: surfaces.outer,
         shape: { type: "rect", cornerRadius: 26, style: "continuous" },
       }}
       frame={{ minWidth: 0, maxWidth: Infinity, minHeight: 0, maxHeight: Infinity }}
@@ -52,6 +54,20 @@ function SmallCardSurface(props: { children: any }) {
       <Spacer minLength={2} />
     </VStack>
   )
+
+  if (!surfaces.border) return body
+
+  return (
+    <VStack
+      padding={{ top: 2, leading: 2, bottom: 2, trailing: 2 }}
+      widgetBackground={{
+        style: surfaces.border,
+        shape: { type: "rect", cornerRadius: 28, style: "continuous" },
+      }}
+    >
+      {body}
+    </VStack>
+  )
 }
 
 // =====================================================================
@@ -60,7 +76,9 @@ function SmallCardSurface(props: { children: any }) {
 function ContentCard(props: {
   children: any
   padding?: { top: number; leading: number; bottom: number; trailing: number }
+  surfaces?: WidgetSurfacePalette
 }) {
+  const surfaces = props.surfaces ?? DEFAULT_WIDGET_SURFACES
   const pad = props.padding ?? { top: 6, leading: 10, bottom: 6, trailing: 10 }
   return (
     <VStack
@@ -68,7 +86,7 @@ function ContentCard(props: {
       padding={pad}
       frame={{ minWidth: 0, maxWidth: Infinity }}
       widgetBackground={{
-        style: { light: "rgba(0,0,0,0.04)", dark: "rgba(255,255,255,0.06)" } as any,
+        style: surfaces.content,
         shape: { type: "rect", cornerRadius: 16, style: "continuous" },
       }}
     >
@@ -85,7 +103,9 @@ function TintPanel(props: {
   cornerRadius?: number
   padding?: { top: number; leading: number; bottom: number; trailing: number }
   spacing?: number
+  surfaces?: WidgetSurfacePalette
 }) {
+  const surfaces = props.surfaces ?? DEFAULT_WIDGET_SURFACES
   const r = props.cornerRadius ?? 16
   const pad = props.padding ?? { top: 8, leading: 10, bottom: 8, trailing: 10 }
   const sp = props.spacing ?? 6
@@ -96,7 +116,7 @@ function TintPanel(props: {
       padding={pad}
       frame={{ minWidth: 0, maxWidth: Infinity }}
       widgetBackground={{
-        style: { light: "rgba(0,0,0,0.03)", dark: "rgba(255,255,255,0.07)" } as any,
+        style: surfaces.panel,
         shape: { type: "rect", cornerRadius: r, style: "continuous" },
       }}
     >
@@ -147,6 +167,10 @@ function SymbolImage(props: { systemName: string; size: number; tint: any; opaci
   )
 }
 
+function useSurfacesFromProps(props: { surfaces?: WidgetSurfacePalette }) {
+  return props?.surfaces ?? DEFAULT_WIDGET_SURFACES
+}
+
 function UnitPill(props: { text: string; tint: any }) {
   return (
     <VStack
@@ -169,14 +193,15 @@ function UnitPill(props: { text: string; tint: any }) {
   )
 }
 
-function MorePill(props: { child?: any }) {
+function MorePill(props: { child?: any; surfaces?: WidgetSurfacePalette }) {
+  const surfaces = props.surfaces ?? DEFAULT_WIDGET_SURFACES
   return (
     <HStack
       alignment="center"
       spacing={0}
       frame={{ width: 44, height: 28 }}
       widgetBackground={{
-        style: { light: "rgba(0,0,0,0.10)", dark: "rgba(255,255,255,0.12)" } as any,
+        style: surfaces.chip,
         shape: { type: "capsule", style: "continuous" },
       }}
     >
@@ -340,6 +365,7 @@ export const SMALL_STYLE_OPTIONS: Array<{ key: SmallStyleKey; nameCN: string; na
 // Style · CompactList（紧凑清单）
 // =====================================================================
 export function CompactListSmallStyle(props: SmallCardCommonProps) {
+  const surfaces = useSurfacesFromProps(props)
   const fee = parseFeeText(props.feeText)
 
   const useTotal = !!props.smallMiniBarUseTotalFlow
@@ -368,7 +394,10 @@ export function CompactListSmallStyle(props: SmallCardCommonProps) {
           </Text>
         </Left>
       </VStack>
-      <MorePill child={<SymbolImage systemName={p.theme.icon} size={15} tint={p.theme.tint} opacity={0.9} />} />
+      <MorePill
+        surfaces={surfaces}
+        child={<SymbolImage systemName={p.theme.icon} size={15} tint={p.theme.tint} opacity={0.9} />}
+      />
     </HStack>
   )
 
@@ -377,7 +406,7 @@ export function CompactListSmallStyle(props: SmallCardCommonProps) {
   const voiceText = `${String(props.voiceValue ?? "0")}${String(props.voiceUnit ?? "") || "分钟"}`
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface surfaces={surfaces}>
       <VStack spacing={4} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
         <HStack alignment="top" spacing={6} frame={{ minWidth: 0, maxWidth: Infinity }}>
           <VStack spacing={2} alignment="leading" frame={{ minWidth: 0, maxWidth: Infinity }}>
@@ -413,7 +442,7 @@ export function CompactListSmallStyle(props: SmallCardCommonProps) {
           padding={{ top: 7, leading: 10, bottom: 7, trailing: 10 }}
           spacing={showOther ? 7 : 8}
           widgetBackground={{
-            style: { light: "rgba(0,0,0,0.06)", dark: "rgba(255,255,255,0.08)" } as any,
+            style: surfaces.panel,
             shape: { type: "rect", cornerRadius: 18, style: "continuous" },
           }}
           frame={{ minWidth: 0, maxWidth: Infinity }}
@@ -431,6 +460,7 @@ export function CompactListSmallStyle(props: SmallCardCommonProps) {
 // Style · ProgressList（进度清单）
 // =====================================================================
 export function ProgressListSmallStyle(props: SmallCardCommonProps) {
+  const surfaces = useSurfacesFromProps(props)
   const fee = parseFeeText(props.feeText)
 
   const useTotal = !!props.smallMiniBarUseTotalFlow
@@ -443,7 +473,7 @@ export function ProgressListSmallStyle(props: SmallCardCommonProps) {
   const flowRatio = useTotal ? props.totalFlowRatio : props.flowRatio
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface surfaces={surfaces}>
       <VStack spacing={4} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
         <HStack alignment="top" spacing={6} frame={{ minWidth: 0, maxWidth: Infinity }}>
           <VStack spacing={2} alignment="leading" frame={{ minWidth: 0, maxWidth: Infinity }}>
@@ -479,7 +509,7 @@ export function ProgressListSmallStyle(props: SmallCardCommonProps) {
           padding={{ top: 7, leading: 10, bottom: 7, trailing: 10 }}
           spacing={showOther ? 7 : 8}
           widgetBackground={{
-            style: { light: "rgba(0,0,0,0.06)", dark: "rgba(255,255,255,0.08)" } as any,
+            style: surfaces.panel,
             shape: { type: "rect", cornerRadius: 18, style: "continuous" },
           }}
           frame={{ minWidth: 0, maxWidth: Infinity }}
@@ -519,6 +549,7 @@ export function ProgressListSmallStyle(props: SmallCardCommonProps) {
 // Style · 三条信息卡
 // =====================================================================
 export function TripleRowsSmallStyle(props: SmallCardCommonProps) {
+  const surfaces = useSurfacesFromProps(props)
   const fee = parseFeeText(props.feeText)
 
   const Row = (p: { theme: RingCardTheme; title: string; value: string; unit: string; rightLogo?: boolean }) => (
@@ -540,15 +571,15 @@ export function TripleRowsSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface surfaces={surfaces}>
       <VStack spacing={10} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard>
+        <ContentCard surfaces={surfaces}>
           <Row theme={ringThemes.fee} title={props.feeTitle || "剩余话费"} value={fee.balance} unit={fee.unit || "元"} rightLogo />
         </ContentCard>
-        <ContentCard>
+        <ContentCard surfaces={surfaces}>
           <Row theme={ringThemes.flow} title={props.flowLabel || "剩余流量"} value={String(props.flowValue ?? "0")} unit={String(props.flowUnit ?? "")} />
         </ContentCard>
-        <ContentCard>
+        <ContentCard surfaces={surfaces}>
           <Row theme={ringThemes.voice} title={props.voiceLabel || "剩余语音"} value={String(props.voiceValue ?? "0")} unit={String(props.voiceUnit ?? "") || "分钟"} />
         </ContentCard>
       </VStack>
@@ -560,6 +591,7 @@ export function TripleRowsSmallStyle(props: SmallCardCommonProps) {
 // Style · 圆标信息卡
 // =====================================================================
 export function IconCellsSmallStyle(props: SmallCardCommonProps) {
+  const surfaces = useSurfacesFromProps(props)
   const fee = parseFeeText(props.feeText)
 
   const Cell = (p: { theme: RingCardTheme; title: string; value: string; unit: string; leftLogo?: boolean }) => (
@@ -590,17 +622,17 @@ export function IconCellsSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface surfaces={surfaces}>
       <VStack spacing={4} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
+        <ContentCard surfaces={surfaces} padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
           <Cell theme={ringThemes.fee} title={props.feeTitle || "剩余话费"} value={fee.balance} unit={fee.unit || "元"} leftLogo />
         </ContentCard>
 
-        <ContentCard padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
+        <ContentCard surfaces={surfaces} padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
           <Cell theme={ringThemes.flow} title={props.flowLabel || "剩余流量"} value={String(props.flowValue ?? "0")} unit={String(props.flowUnit ?? "")} />
         </ContentCard>
 
-        <ContentCard padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
+        <ContentCard surfaces={surfaces} padding={{ top: 5, leading: 9, bottom: 5, trailing: 9 }}>
           <Cell theme={ringThemes.voice} title={props.voiceLabel || "剩余语音"} value={String(props.voiceValue ?? "0")} unit={String(props.voiceUnit ?? "") || "分钟"} />
         </ContentCard>
       </VStack>
@@ -612,6 +644,7 @@ export function IconCellsSmallStyle(props: SmallCardCommonProps) {
 // Style · 余额主卡 + 下两块
 // =====================================================================
 export function BalanceFocusSmallStyle(props: SmallCardCommonProps) {
+  const surfaces = useSurfacesFromProps(props)
   const fee = parseFeeText(props.feeText)
 
   const BLOCK_W = 80
@@ -623,7 +656,7 @@ export function BalanceFocusSmallStyle(props: SmallCardCommonProps) {
 
   const MiniBlock = (p: { theme: RingCardTheme; label: string; value: string }) => (
     <VStack frame={{ width: BLOCK_W }}>
-      <ContentCard padding={{ top: 6, leading: 6, bottom: 6, trailing: 6 }}>
+      <ContentCard surfaces={surfaces} padding={{ top: 6, leading: 6, bottom: 6, trailing: 6 }}>
         <VStack spacing={4} alignment="center" frame={{ width: BLOCK_W - 12, height: BLOCK_H }}>
           <SymbolImage systemName={p.theme.icon} size={16} tint={p.theme.tint} opacity={0.9} />
           <Text font={9} foregroundStyle={timeStyle} lineLimit={1} minScaleFactor={0.7}>
@@ -638,9 +671,9 @@ export function BalanceFocusSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface surfaces={surfaces}>
       <VStack spacing={0} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard padding={{ top: 7, leading: 8, bottom: 4, trailing: 8 }}>
+        <ContentCard surfaces={surfaces} padding={{ top: 7, leading: 8, bottom: 4, trailing: 8 }}>
           <VStack frame={{ minWidth: 0, maxWidth: Infinity, height: TOP_MIN_H }} alignment="leading">
             <HStack alignment="center" spacing={8} frame={{ minWidth: 0, maxWidth: Infinity }}>
               <VStack spacing={2} alignment="leading" frame={{ minWidth: 0, maxWidth: Infinity }}>
@@ -690,6 +723,7 @@ export function BalanceFocusSmallStyle(props: SmallCardCommonProps) {
 // Style · 上余额下列表
 // =====================================================================
 export function DualListSmallStyle(props: SmallCardCommonProps) {
+  const surfaces = useSurfacesFromProps(props)
   const fee = parseFeeText(props.feeText)
   const showOther = !!(props.otherFlowLabel && String(props.otherFlowLabel).trim().length > 0)
 
@@ -701,9 +735,9 @@ export function DualListSmallStyle(props: SmallCardCommonProps) {
   const otherUnitText = String(props.otherFlowUnit ?? "GB").toUpperCase()
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface surfaces={surfaces}>
       <VStack spacing={10} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard>
+        <ContentCard surfaces={surfaces}>
           <HStack alignment="top" spacing={6} frame={{ minWidth: 0, maxWidth: Infinity }}>
             <VStack spacing={2} alignment="leading" frame={{ minWidth: 0, maxWidth: Infinity }}>
               <Left>
@@ -734,7 +768,7 @@ export function DualListSmallStyle(props: SmallCardCommonProps) {
           </HStack>
         </ContentCard>
 
-        <TintPanel spacing={showOther ? 6 : 7} cornerRadius={16}>
+        <TintPanel surfaces={surfaces} spacing={showOther ? 6 : 7} cornerRadius={16}>
           <ListRow theme={ringThemes.flow} label={props.flowLabel || "剩余流量"} valueText={flowValueText} unitText={flowUnitText} />
           {showOther ? (
             <ListRow theme={ringThemes.flowDir} label={String(props.otherFlowLabel)} valueText={otherValueText} unitText={otherUnitText} />
@@ -750,6 +784,7 @@ export function DualListSmallStyle(props: SmallCardCommonProps) {
 // Style · 双环仪表（保持原样）
 // =====================================================================
 export function DualGaugesSmallStyle(props: SmallCardCommonProps) {
+  const surfaces = useSurfacesFromProps(props)
   const fee = parseFeeText(props.feeText)
 
   const Ring = (p: { theme: RingCardTheme; title: string; value: string; unit: string }) => (
@@ -789,9 +824,9 @@ export function DualGaugesSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface surfaces={surfaces}>
       <VStack spacing={10} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard>
+        <ContentCard surfaces={surfaces}>
           <HStack alignment="center" spacing={6} frame={{ minWidth: 0, maxWidth: Infinity }}>
             <Spacer />
             <LogoImage logoPath={props.logoPath} size={34} fallbackTheme={ringThemes.fee} />
@@ -837,6 +872,7 @@ export function DualGaugesSmallStyle(props: SmallCardCommonProps) {
 // Style · 文字清单
 // =====================================================================
 export function TextListSmallStyle(props: SmallCardCommonProps) {
+  const surfaces = useSurfacesFromProps(props)
   const fee = parseFeeText(props.feeText)
   const showOther = !!(props.otherFlowLabel && String(props.otherFlowLabel).trim().length > 0)
 
@@ -855,9 +891,9 @@ export function TextListSmallStyle(props: SmallCardCommonProps) {
   )
 
   return (
-    <SmallCardSurface>
+    <SmallCardSurface surfaces={surfaces}>
       <VStack spacing={10} frame={{ minWidth: 0, maxWidth: Infinity }} alignment="leading">
-        <ContentCard>
+        <ContentCard surfaces={surfaces}>
           <HStack alignment="center" spacing={8} frame={{ minWidth: 0, maxWidth: Infinity }}>
             <LogoImage logoPath={props.logoPath} size={22} fallbackTheme={ringThemes.fee} />
             <Spacer />

--- a/Scripting/Source/中國聯通/shared/carrier/cards/small/summaryCardStyle.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/small/summaryCardStyle.tsx
@@ -5,25 +5,27 @@ import { VStack, Spacer } from "scripting"
 import type { SmallCardCommonProps } from "./common"
 import { FeeCard } from "../components/feeCard"
 import { ringThemes } from "../../theme"
+import { SmallCardSurface } from "./smallCardStyles"
+import { DEFAULT_WIDGET_SURFACES } from "../../surfaces"
 
 // summary 样式：直接用 FeeCard 缩小版，只展示话费卡（垂直居中）
 export function TelecomSmallSummaryCard(props: SmallCardCommonProps) {
   const { feeTitle, feeText, logoPath, updateTime } = props
+  const surfaces = props.surfaces ?? DEFAULT_WIDGET_SURFACES
 
   return (
-    <VStack
-      alignment="center"
-      padding={{ top: 4, leading: 4, bottom: 4, trailing: 4 }}
-    >
-      <Spacer />
-      <FeeCard
-        title={feeTitle}
-        valueText={feeText}
-        theme={ringThemes.fee}
-        logoPath={logoPath}
-        updateTime={updateTime ?? ""}
-      />
-      <Spacer />
-    </VStack>
+    <SmallCardSurface surfaces={surfaces}>
+      <VStack alignment="center" padding={{ top: 4, leading: 4, bottom: 4, trailing: 4 }}>
+        <Spacer />
+        <FeeCard
+          title={feeTitle}
+          valueText={feeText}
+          theme={ringThemes.fee}
+          logoPath={logoPath}
+          updateTime={updateTime ?? ""}
+        />
+        <Spacer />
+      </VStack>
+    </SmallCardSurface>
   )
 }

--- a/Scripting/Source/中國聯通/shared/carrier/surfaces.ts
+++ b/Scripting/Source/中國聯通/shared/carrier/surfaces.ts
@@ -1,0 +1,47 @@
+// shared/carrier/surfaces.ts
+// 统一外观：控制透明/描边样式
+
+import { DynamicShapeStyle } from "scripting"
+import { outerCardBg, ringThemes } from "./theme"
+
+export type WidgetSurfacePalette = {
+  outer: DynamicShapeStyle | string
+  content: DynamicShapeStyle | string
+  panel: DynamicShapeStyle | string
+  pill: DynamicShapeStyle | string
+  chip: DynamicShapeStyle | string
+  border?: DynamicShapeStyle | string
+}
+
+type SurfaceOptions = {
+  transparentStyle?: boolean
+  colorfulLineBorder?: boolean
+}
+
+const OPAQUE_SURFACES: WidgetSurfacePalette = {
+  outer: outerCardBg,
+  content: { light: "rgba(0,0,0,0.04)", dark: "rgba(255,255,255,0.06)" } as DynamicShapeStyle,
+  panel: { light: "rgba(0,0,0,0.03)", dark: "rgba(255,255,255,0.07)" } as DynamicShapeStyle,
+  pill: { light: "rgba(0,0,0,0.10)", dark: "rgba(255,255,255,0.10)" } as DynamicShapeStyle,
+  chip: { light: "rgba(0,0,0,0.10)", dark: "rgba(255,255,255,0.12)" } as DynamicShapeStyle,
+}
+
+const TRANSPARENT_SURFACES: WidgetSurfacePalette = {
+  outer: { light: "rgba(255,255,255,0.06)", dark: "rgba(0,0,0,0.18)" } as DynamicShapeStyle,
+  content: { light: "rgba(255,255,255,0.08)", dark: "rgba(255,255,255,0.14)" } as DynamicShapeStyle,
+  panel: { light: "rgba(255,255,255,0.06)", dark: "rgba(255,255,255,0.12)" } as DynamicShapeStyle,
+  pill: { light: "rgba(255,255,255,0.16)", dark: "rgba(255,255,255,0.20)" } as DynamicShapeStyle,
+  chip: { light: "rgba(255,255,255,0.16)", dark: "rgba(255,255,255,0.22)" } as DynamicShapeStyle,
+  border: { light: "rgba(255,255,255,0.28)", dark: "rgba(255,255,255,0.34)" } as DynamicShapeStyle,
+}
+
+export const DEFAULT_WIDGET_SURFACES: WidgetSurfacePalette = { ...OPAQUE_SURFACES }
+
+export function buildWidgetSurfaces(options: SurfaceOptions): WidgetSurfacePalette {
+  const { transparentStyle, colorfulLineBorder } = options
+  if (!transparentStyle) return { ...OPAQUE_SURFACES }
+
+  const base = { ...OPAQUE_SURFACES, ...TRANSPARENT_SURFACES }
+  const border = colorfulLineBorder ? ringThemes.flow.tint : base.border
+  return { ...base, border }
+}

--- a/Scripting/Source/中國聯通/shared/carrier/ui.ts
+++ b/Scripting/Source/中國聯通/shared/carrier/ui.ts
@@ -28,6 +28,8 @@ export type UiSettings = {
   smallCardStyle: SmallCardStyle
   smallMiniBarUseTotalFlow: boolean
   includeDirectionalInTotal: boolean
+  transparentWidgetStyle: boolean
+  colorfulLineBorder: boolean
 }
 
 /**
@@ -45,6 +47,8 @@ const DEFAULT_UI: UiSettings = {
   smallCardStyle: "CompactList",
   smallMiniBarUseTotalFlow: false,
   includeDirectionalInTotal: true,
+  transparentWidgetStyle: false,
+  colorfulLineBorder: false,
 }
 
 const VALID_SMALL_STYLE_SET = new Set<string>([
@@ -69,6 +73,9 @@ export function pickUiSettings(src?: UiSwitchSource): UiSettings {
       typeof s.smallMiniBarUseTotalFlow === "boolean" ? s.smallMiniBarUseTotalFlow : DEFAULT_UI.smallMiniBarUseTotalFlow,
     includeDirectionalInTotal:
       typeof s.includeDirectionalInTotal === "boolean" ? s.includeDirectionalInTotal : DEFAULT_UI.includeDirectionalInTotal,
+    transparentWidgetStyle:
+      typeof s.transparentWidgetStyle === "boolean" ? s.transparentWidgetStyle : DEFAULT_UI.transparentWidgetStyle,
+    colorfulLineBorder: typeof s.colorfulLineBorder === "boolean" ? s.colorfulLineBorder : DEFAULT_UI.colorfulLineBorder,
   }
 }
 

--- a/Scripting/Source/中國聯通/shared/carrier/widgetRoot.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/widgetRoot.tsx
@@ -22,6 +22,7 @@ import { Widget, VStack, HStack } from "scripting"
 import { outerCardBg, ringThemes } from "./theme"
 import { buildUsageStat, formatFlowValue } from "./utils/carrierUtils"
 import type { UiSettings } from "./ui"
+import { buildWidgetSurfaces } from "./surfaces"
 
 import { MediumLayout } from "./cards/medium"
 import { FeeCard } from "./cards/components/feeCard"
@@ -70,6 +71,11 @@ export type CarrierData = {
 
 export function WidgetRoot(props: { data: CarrierData; ui: UiSettings; logoPath: string }) {
   const { data, ui, logoPath } = props
+
+  const surfaces = buildWidgetSurfaces({
+    transparentStyle: ui.transparentWidgetStyle,
+    colorfulLineBorder: ui.colorfulLineBorder,
+  })
 
   const {
     showRemainRatio,
@@ -144,6 +150,7 @@ export function WidgetRoot(props: { data: CarrierData; ui: UiSettings; logoPath:
     return (
       <SmallLayout
         style={style}
+        surfaces={surfaces}
         feeTitle={data.fee.title}
         feeText={`${data.fee.balance}${data.fee.unit}`}
         logoPath={logoPath}
@@ -175,6 +182,7 @@ export function WidgetRoot(props: { data: CarrierData; ui: UiSettings; logoPath:
     return (
       <MediumLayout
         layout={mediumStyle}
+        surfaces={surfaces}
         feeTitle={data.fee.title}
         feeText={`${data.fee.balance}${data.fee.unit}`}
         logoPath={logoPath}
@@ -194,12 +202,12 @@ export function WidgetRoot(props: { data: CarrierData; ui: UiSettings; logoPath:
 
   // ==================== 大号 ====================
 
-  return (
+  const body = (
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 10, bottom: 10, trailing: 10 }}
       widgetBackground={{
-        style: outerCardBg,
+        style: surfaces.outer || outerCardBg,
         shape: { type: "rect", cornerRadius: 24, style: "continuous" },
       }}
     >
@@ -233,6 +241,20 @@ export function WidgetRoot(props: { data: CarrierData; ui: UiSettings; logoPath:
           ratio={voiceStat.ratio}
         />
       </HStack>
+    </VStack>
+  )
+
+  if (!surfaces.border) return body
+
+  return (
+    <VStack
+      padding={{ top: 2, leading: 2, bottom: 2, trailing: 2 }}
+      widgetBackground={{
+        style: surfaces.border,
+        shape: { type: "rect", cornerRadius: 26, style: "continuous" },
+      }}
+    >
+      {body}
     </VStack>
   )
 }

--- a/Scripting/Source/中國聯通/shared/ui-kit/renderConfigSection.tsx
+++ b/Scripting/Source/中國聯通/shared/ui-kit/renderConfigSection.tsx
@@ -10,6 +10,11 @@ type RenderConfigSectionProps = {
   showRemainRatio: boolean
   setShowRemainRatio: (v: boolean) => void
 
+  transparentWidgetStyle: boolean
+  setTransparentWidgetStyle: (v: boolean) => void
+  colorfulLineBorder: boolean
+  setColorfulLineBorder: (v: boolean) => void
+
   // 小号
   smallCardStyle: SmallCardStyle
   setSmallCardStyle: (v: SmallCardStyle) => void
@@ -61,6 +66,11 @@ export function RenderConfigSection(props: RenderConfigSectionProps) {
     showRemainRatio,
     setShowRemainRatio,
 
+    transparentWidgetStyle,
+    setTransparentWidgetStyle,
+    colorfulLineBorder,
+    setColorfulLineBorder,
+
     smallCardStyle,
     setSmallCardStyle,
     smallMiniBarUseTotalFlow,
@@ -97,6 +107,7 @@ export function RenderConfigSection(props: RenderConfigSectionProps) {
           {"\n"}• 百分比含义：作用于通用/定向/语音（或总流量/语音），由「显示剩余/已使用」决定。
           {"\n"}• 中号组件：样式=全圆环/仪表盘；布局=三卡/四卡（三卡会隐藏定向卡）。
           {"\n"}• 三卡布局下：可选择“总流量包含定向”或“仅通用流量”。
+          {"\n"}• 外观：可切换透明外观；透明时可叠加彩色描边。
           {"\n"}• 刷新间隔建议 15 分钟～24 小时（系统调度可能更慢）。
         </Text>
       }
@@ -106,6 +117,20 @@ export function RenderConfigSection(props: RenderConfigSectionProps) {
         value={showRemainRatio}
         onChanged={setShowRemainRatio}
       />
+
+      <Toggle
+        title={transparentWidgetStyle ? "外观：透明小组件" : "外观：不透明小组件"}
+        value={transparentWidgetStyle}
+        onChanged={setTransparentWidgetStyle}
+      />
+
+      {transparentWidgetStyle ? (
+        <Toggle
+          title={colorfulLineBorder ? "透明模式：彩色描边" : "透明模式：浅色描边"}
+          value={colorfulLineBorder}
+          onChanged={setColorfulLineBorder}
+        />
+      ) : null}
 
       {/* ==================== 小号 ==================== */}
       <Picker


### PR DESCRIPTION
## Summary
- add a shared surface palette to support opaque and transparent widget looks with optional colored outlines
- expose transparent style and outline switches in the render configuration UI and persist them in settings
- apply the surface palette across small, medium, and large widget layouts for consistent styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947dbd8ffe08326bd8fa6f875858ef9)