### PR TITLE
Refine widget surfaces and outlines

### DIFF
--- a/Scripting/Source/中國聯通/shared/carrier/cards/components/dialRingStatCard.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/components/dialRingStatCard.tsx
@@ -2,6 +2,7 @@
 
 import { VStack, Text, Image, Spacer, ZStack, Gauge } from "scripting"
 import { RingCardTheme, timeStyle } from "../../theme"
+import { type WidgetSurfacePalette, wrapWithBorderLayer } from "../../surfaces"
 import { clamp01, percentText } from "../../utils/carrierUtils"
 
 const Empty = <Text font={1}> </Text>
@@ -16,17 +17,20 @@ export function DialRingStatCard(props: {
   valueText: string
   theme: RingCardTheme
   ratio?: number
+  surfaces?: WidgetSurfacePalette
 }) {
-  const { title, valueText, theme, ratio } = props
+  const { title, valueText, theme, ratio, surfaces } = props
   const r = clamp01(ratio ?? 0)
 
-  return (
+  const background = surfaces?.panel ?? theme.bg
+
+  const card = (
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 8, bottom: 10, trailing: 8 }}
       frame={{ minWidth: 0, maxWidth: Infinity }}
       widgetBackground={{
-        style: theme.bg,
+        style: background,
         shape: { type: "rect", cornerRadius: 18, style: "continuous" },
       }}
     >
@@ -83,4 +87,6 @@ export function DialRingStatCard(props: {
       <Spacer minLength={4} />
     </VStack>
   )
+
+  return wrapWithBorderLayer({ child: card, surfaces, cornerRadius: 18, padding: 2 })
 }

--- a/Scripting/Source/中國聯通/shared/carrier/cards/components/feeCard.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/components/feeCard.tsx
@@ -1,12 +1,7 @@
 // shared/carrier/cards/components/feeCard.tsx
-import {
-  VStack,
-  HStack,
-  Text,
-  Image,
-  Spacer,
-} from "scripting"
+import { VStack, HStack, Text, Image, Spacer } from "scripting"
 import { timeStyle, RingCardTheme } from "../../theme"
+import { type WidgetSurfacePalette, wrapWithBorderLayer } from "../../surfaces"
 
 export function FeeCard(props: {
   title: string
@@ -14,10 +9,13 @@ export function FeeCard(props: {
   theme: RingCardTheme
   logoPath?: string | null
   updateTime: string
+  surfaces?: WidgetSurfacePalette
 }) {
-  const { title, valueText, theme, logoPath, updateTime } = props
+  const { title, valueText, theme, logoPath, updateTime, surfaces } = props
   const isUrlLogo =
     !!logoPath && (logoPath.startsWith("http://") || logoPath.startsWith("https://"))
+
+  const background = surfaces?.content ?? theme.bg
 
   const LogoImage = ({ size }: { size: number }) =>
     logoPath ? (
@@ -35,13 +33,13 @@ export function FeeCard(props: {
       />
     )
 
-  return (
+  const card = (
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 10, bottom: 10, trailing: 10 }}
       frame={{ minWidth: 0, maxWidth: Infinity }}
       widgetBackground={{
-        style: theme.bg,
+        style: background,
         shape: { type: "rect", cornerRadius: 18, style: "continuous" },
       }}
     >
@@ -97,4 +95,6 @@ export function FeeCard(props: {
       <Spacer minLength={4} />
     </VStack>
   )
+
+  return wrapWithBorderLayer({ child: card, surfaces, cornerRadius: 18, padding: 2 })
 }

--- a/Scripting/Source/中國聯通/shared/carrier/cards/components/fullRingStatCard.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/components/fullRingStatCard.tsx
@@ -2,6 +2,7 @@
 
 import { VStack, Text, Image, Spacer, ZStack, Gauge } from "scripting"
 import { RingCardTheme, timeStyle } from "../../theme"
+import { type WidgetSurfacePalette, wrapWithBorderLayer } from "../../surfaces"
 import { clamp01, percentText } from "../../utils/carrierUtils"
 
 /**
@@ -13,17 +14,20 @@ export function FullRingStatCard(props: {
   valueText: string
   theme: RingCardTheme
   ratio?: number
+  surfaces?: WidgetSurfacePalette
 }) {
-  const { title, valueText, theme, ratio } = props
+  const { title, valueText, theme, ratio, surfaces } = props
   const r = clamp01(ratio ?? 0)
 
-  return (
+  const background = surfaces?.panel ?? theme.bg
+
+  const card = (
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 8, bottom: 10, trailing: 8 }}
       frame={{ minWidth: 0, maxWidth: Infinity }}
       widgetBackground={{
-        style: theme.bg,
+        style: background,
         shape: { type: "rect", cornerRadius: 18, style: "continuous" },
       }}
     >
@@ -80,4 +84,6 @@ export function FullRingStatCard(props: {
       <Spacer minLength={4} />
     </VStack>
   )
+
+  return wrapWithBorderLayer({ child: card, surfaces, cornerRadius: 18, padding: 2 })
 }

--- a/Scripting/Source/中國聯通/shared/carrier/cards/large/index.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/large/index.tsx
@@ -1,12 +1,10 @@
 // shared/carrier/cards/large/index.tsx
 // 大号组件布局：四卡（话费 + 通用流量 + 定向流量 + 语音）
 
-import {
-  VStack,
-  HStack,
-} from "scripting"
+import { VStack, HStack } from "scripting"
 
 import { outerCardBg, ringThemes } from "../../theme"
+import { type WidgetSurfacePalette, wrapWithBorderLayer } from "../../surfaces"
 import { FeeCard } from "../components/feeCard"
 import { FullRingStatCard } from "../components/fullRingStatCard"
 
@@ -16,6 +14,8 @@ export type TelecomLargeLayoutProps = {
   feeText: string
   logoPath: string
   updateTime: string
+
+  surfaces?: WidgetSurfacePalette
 
   // 通用流量
   flowTitle: string
@@ -48,14 +48,15 @@ export function TelecomLargeLayout(props: TelecomLargeLayoutProps) {
     voiceTitle,
     voiceValueText,
     voiceRatio,
+    surfaces,
   } = props
 
-  return (
+  const body = (
     <VStack
       alignment="center"
       padding={{ top: 10, leading: 10, bottom: 10, trailing: 10 }}
       widgetBackground={{
-        style: outerCardBg,
+        style: surfaces?.outer || outerCardBg,
         shape: { type: "rect", cornerRadius: 24, style: "continuous" },
       }}
     >
@@ -66,6 +67,7 @@ export function TelecomLargeLayout(props: TelecomLargeLayoutProps) {
           theme={ringThemes.fee}
           logoPath={logoPath}
           updateTime={updateTime}
+          surfaces={surfaces}
         />
 
         <FullRingStatCard
@@ -73,6 +75,7 @@ export function TelecomLargeLayout(props: TelecomLargeLayoutProps) {
           valueText={flowValueText}
           theme={ringThemes.flow}
           ratio={flowRatio}
+          surfaces={surfaces}
         />
 
         <FullRingStatCard
@@ -80,6 +83,7 @@ export function TelecomLargeLayout(props: TelecomLargeLayoutProps) {
           valueText={otherValueText}
           theme={ringThemes.flowDir}
           ratio={otherRatio}
+          surfaces={surfaces}
         />
 
         <FullRingStatCard
@@ -87,8 +91,11 @@ export function TelecomLargeLayout(props: TelecomLargeLayoutProps) {
           valueText={voiceValueText}
           theme={ringThemes.voice}
           ratio={voiceRatio}
+          surfaces={surfaces}
         />
       </HStack>
     </VStack>
   )
+
+  return wrapWithBorderLayer({ child: body, surfaces, cornerRadius: 24, padding: 2 })
 }

--- a/Scripting/Source/中國聯通/shared/carrier/cards/medium/common.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/medium/common.tsx
@@ -1,7 +1,7 @@
 // shared/carrier/cards/medium/common.tsx
 import { VStack, HStack } from "scripting"
 import { outerCardBg } from "../../theme"
-import { type WidgetSurfacePalette, DEFAULT_WIDGET_SURFACES } from "../../surfaces"
+import { type WidgetSurfacePalette, DEFAULT_WIDGET_SURFACES, wrapWithBorderLayer } from "../../surfaces"
 
 export type MediumStyleKey = "FullRing" | "DialRing"
 
@@ -43,17 +43,5 @@ export function MediumOuter(props: { children: any; surfaces?: WidgetSurfacePale
     </VStack>
   )
 
-  if (!surfaces.border) return body
-
-  return (
-    <VStack
-      padding={{ top: 2, leading: 2, bottom: 2, trailing: 2 }}
-      widgetBackground={{
-        style: surfaces.border,
-        shape: { type: "rect", cornerRadius: 26, style: "continuous" },
-      }}
-    >
-      {body}
-    </VStack>
-  )
+  return wrapWithBorderLayer({ child: body, surfaces, cornerRadius: 24, padding: 2 })
 }

--- a/Scripting/Source/中國聯通/shared/carrier/cards/medium/styles/DialRingCardStyle.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/medium/styles/DialRingCardStyle.tsx
@@ -26,6 +26,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
     voiceTitle,
     voiceValueText,
     voiceRatio,
+    surfaces,
   } = props
 
   const showOther =
@@ -40,6 +41,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
         theme={ringThemes.fee}
         logoPath={logoPath}
         updateTime={updateTime}
+        surfaces={surfaces}
       />
 
       <DialRingStatCard
@@ -47,6 +49,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
         valueText={flowValueText}
         theme={ringThemes.flow}
         ratio={flowRatio}
+        surfaces={surfaces}
       />
 
       {showOther ? (
@@ -56,6 +59,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
           valueText={otherValueText ?? "0MB"}
           theme={ringThemes.flowDir}
           ratio={otherRatio ?? 0}
+          surfaces={surfaces}
         />
       ) : null}
 
@@ -64,6 +68,7 @@ export function DialRingCardStyle(props: MediumCommonProps) {
         valueText={voiceValueText}
         theme={ringThemes.voice}
         ratio={voiceRatio}
+        surfaces={surfaces}
       />
     </MediumOuter>
   )

--- a/Scripting/Source/中國聯通/shared/carrier/cards/medium/styles/FullRingCardStyle.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/medium/styles/FullRingCardStyle.tsx
@@ -25,6 +25,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
     voiceTitle,
     voiceValueText,
     voiceRatio,
+    surfaces,
   } = props
 
   const showOther =
@@ -39,6 +40,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
         theme={ringThemes.fee}
         logoPath={logoPath}
         updateTime={updateTime}
+        surfaces={surfaces}
       />
 
       <FullRingStatCard
@@ -46,6 +48,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
         valueText={flowValueText}
         theme={ringThemes.flow}
         ratio={flowRatio}
+        surfaces={surfaces}
       />
 
       {showOther ? (
@@ -55,6 +58,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
           valueText={otherValueText ?? "0MB"}
           theme={ringThemes.flowDir}
           ratio={otherRatio ?? 0}
+          surfaces={surfaces}
         />
       ) : null}
 
@@ -63,6 +67,7 @@ export function FullRingCardStyle(props: MediumCommonProps) {
         valueText={voiceValueText}
         theme={ringThemes.voice}
         ratio={voiceRatio}
+        surfaces={surfaces}
       />
     </MediumOuter>
   )

--- a/Scripting/Source/中國聯通/shared/carrier/cards/small/smallCardStyles.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/small/smallCardStyles.tsx
@@ -4,7 +4,7 @@ import { VStack, HStack, ZStack, Text, Spacer, Image } from "scripting"
 import type { SmallCardCommonProps } from "./common"
 import { ringThemes, timeStyle } from "../../theme"
 import type { RingCardTheme } from "../../theme"
-import { DEFAULT_WIDGET_SURFACES, type WidgetSurfacePalette } from "../../surfaces"
+import { DEFAULT_WIDGET_SURFACES, type WidgetSurfacePalette, wrapWithBorderLayer } from "../../surfaces"
 
 // =====================================================================
 // Layout Helpers · 强制“靠左”
@@ -55,19 +55,7 @@ export function SmallCardSurface(props: { children: any; surfaces?: WidgetSurfac
     </VStack>
   )
 
-  if (!surfaces.border) return body
-
-  return (
-    <VStack
-      padding={{ top: 2, leading: 2, bottom: 2, trailing: 2 }}
-      widgetBackground={{
-        style: surfaces.border,
-        shape: { type: "rect", cornerRadius: 28, style: "continuous" },
-      }}
-    >
-      {body}
-    </VStack>
-  )
+  return wrapWithBorderLayer({ child: body, surfaces, cornerRadius: 26, padding: 2 })
 }
 
 // =====================================================================

--- a/Scripting/Source/中國聯通/shared/carrier/cards/small/summaryCardStyle.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/cards/small/summaryCardStyle.tsx
@@ -23,6 +23,7 @@ export function TelecomSmallSummaryCard(props: SmallCardCommonProps) {
           theme={ringThemes.fee}
           logoPath={logoPath}
           updateTime={updateTime ?? ""}
+          surfaces={surfaces}
         />
         <Spacer />
       </VStack>

--- a/Scripting/Source/中國聯通/shared/carrier/surfaces.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/surfaces.tsx
@@ -1,0 +1,69 @@
+// shared/carrier/surfaces.ts
+// 统一外观：控制透明/描边样式
+
+import { DynamicShapeStyle, VStack } from "scripting"
+import { outerCardBg, ringThemes } from "./theme"
+
+export type WidgetSurfacePalette = {
+  outer: DynamicShapeStyle | string
+  content: DynamicShapeStyle | string
+  panel: DynamicShapeStyle | string
+  pill: DynamicShapeStyle | string
+  chip: DynamicShapeStyle | string
+  border?: DynamicShapeStyle | string
+}
+
+type SurfaceOptions = {
+  transparentStyle?: boolean
+  colorfulLineBorder?: boolean
+}
+
+const OPAQUE_SURFACES: WidgetSurfacePalette = {
+  outer: { light: "rgba(255,255,255,0.90)", dark: "rgba(0,0,0,0.55)" } as DynamicShapeStyle,
+  content: { light: "rgba(255,255,255,0.78)", dark: "rgba(255,255,255,0.10)" } as DynamicShapeStyle,
+  panel: { light: "rgba(255,255,255,0.70)", dark: "rgba(255,255,255,0.08)" } as DynamicShapeStyle,
+  pill: { light: "rgba(255,255,255,0.78)", dark: "rgba(255,255,255,0.12)" } as DynamicShapeStyle,
+  chip: { light: "rgba(255,255,255,0.78)", dark: "rgba(255,255,255,0.14)" } as DynamicShapeStyle,
+}
+
+const TRANSPARENT_SURFACES: WidgetSurfacePalette = {
+  outer: { light: "rgba(255,255,255,0.04)", dark: "rgba(0,0,0,0.18)" } as DynamicShapeStyle,
+  content: { light: "rgba(255,255,255,0.06)", dark: "rgba(255,255,255,0.12)" } as DynamicShapeStyle,
+  panel: { light: "rgba(255,255,255,0.05)", dark: "rgba(255,255,255,0.10)" } as DynamicShapeStyle,
+  pill: { light: "rgba(255,255,255,0.12)", dark: "rgba(255,255,255,0.16)" } as DynamicShapeStyle,
+  chip: { light: "rgba(255,255,255,0.12)", dark: "rgba(255,255,255,0.18)" } as DynamicShapeStyle,
+  border: { light: "rgba(255,255,255,0.18)", dark: "rgba(255,255,255,0.28)" } as DynamicShapeStyle,
+}
+
+export const DEFAULT_WIDGET_SURFACES: WidgetSurfacePalette = { ...OPAQUE_SURFACES }
+
+export function buildWidgetSurfaces(options: SurfaceOptions): WidgetSurfacePalette {
+  const { transparentStyle, colorfulLineBorder } = options
+  if (!transparentStyle) return { ...OPAQUE_SURFACES }
+
+  const base = { ...OPAQUE_SURFACES, ...TRANSPARENT_SURFACES }
+  const border = colorfulLineBorder ? ringThemes.flow.tint : base.border
+  return { ...base, border }
+}
+
+export function wrapWithBorderLayer(options: {
+  child: any
+  surfaces?: WidgetSurfacePalette
+  cornerRadius: number
+  padding?: number
+}) {
+  const { child, surfaces, cornerRadius, padding = 2 } = options
+  if (!surfaces?.border) return child
+
+  return (
+    <VStack
+      padding={{ top: padding, leading: padding, bottom: padding, trailing: padding }}
+      widgetBackground={{
+        style: surfaces.border,
+        shape: { type: "rect", cornerRadius: cornerRadius + padding, style: "continuous" },
+      }}
+    >
+      {child}
+    </VStack>
+  )
+}

--- a/Scripting/Source/中國聯通/shared/carrier/theme.ts
+++ b/Scripting/Source/中國聯通/shared/carrier/theme.ts
@@ -15,32 +15,32 @@ export const ringThemes = {
     tint: { light: "#0080CB", dark: "#66adff" } as DynamicShapeStyle,
     icon: "bolt.horizontal.circle.fill",
     bg: {
-      light: "rgba(0,128,203,0.06)",
-      dark: "rgba(5, 16, 32, 0.96)",
+      light: "rgba(0,128,203,0.16)",
+      dark: "rgba(0,128,203,0.24)",
     } as DynamicShapeStyle,
   },
   flow: {
     tint: { light: "#32CD32", dark: "#63e08f" } as DynamicShapeStyle,
     icon: "antenna.radiowaves.left.and.right",
     bg: {
-      light: "rgba(50,205,50,0.08)",
-      dark: "rgba(3, 9, 28, 1.0)",
+      light: "rgba(50,205,50,0.18)",
+      dark: "rgba(50,205,50,0.28)",
     } as DynamicShapeStyle,
   },
   flowDir: {
     tint: { light: "#8A6EFF", dark: "#c59bff" } as DynamicShapeStyle,
     icon: "wifi",
     bg: {
-      light: "rgba(138,110,255,0.10)",
-      dark: "rgba(8, 6, 24, 0.96)",
+      light: "rgba(138,110,255,0.20)",
+      dark: "rgba(138,110,255,0.30)",
     } as DynamicShapeStyle,
   },
   voice: {
     tint: { light: "#F86527", dark: "#ffb07a" } as DynamicShapeStyle,
     icon: "phone.badge.waveform.fill",
     bg: {
-      light: "rgba(248,101,39,0.10)",
-      dark: "rgba(13, 10, 34, 1.0)",
+      light: "rgba(248,101,39,0.20)",
+      dark: "rgba(248,101,39,0.30)",
     } as DynamicShapeStyle,
   },
 } as const

--- a/Scripting/Source/中國聯通/shared/carrier/widgetRoot.tsx
+++ b/Scripting/Source/中國聯通/shared/carrier/widgetRoot.tsx
@@ -22,7 +22,7 @@ import { Widget, VStack, HStack } from "scripting"
 import { outerCardBg, ringThemes } from "./theme"
 import { buildUsageStat, formatFlowValue } from "./utils/carrierUtils"
 import type { UiSettings } from "./ui"
-import { buildWidgetSurfaces } from "./surfaces"
+import { buildWidgetSurfaces, wrapWithBorderLayer } from "./surfaces"
 
 import { MediumLayout } from "./cards/medium"
 import { FeeCard } from "./cards/components/feeCard"
@@ -218,6 +218,7 @@ export function WidgetRoot(props: { data: CarrierData; ui: UiSettings; logoPath:
           theme={ringThemes.fee}
           logoPath={logoPath}
           updateTime={data.updateTime}
+          surfaces={surfaces}
         />
 
         <FullRingStatCard
@@ -225,6 +226,7 @@ export function WidgetRoot(props: { data: CarrierData; ui: UiSettings; logoPath:
           valueText={flowValueText}
           theme={ringThemes.flow}
           ratio={flowStat.ratio}
+          surfaces={surfaces}
         />
 
         <FullRingStatCard
@@ -232,6 +234,7 @@ export function WidgetRoot(props: { data: CarrierData; ui: UiSettings; logoPath:
           valueText={otherValueText}
           theme={ringThemes.flowDir}
           ratio={otherStat.ratio}
+          surfaces={surfaces}
         />
 
         <FullRingStatCard
@@ -239,22 +242,11 @@ export function WidgetRoot(props: { data: CarrierData; ui: UiSettings; logoPath:
           valueText={voiceValueText}
           theme={ringThemes.voice}
           ratio={voiceStat.ratio}
+          surfaces={surfaces}
         />
       </HStack>
     </VStack>
   )
 
-  if (!surfaces.border) return body
-
-  return (
-    <VStack
-      padding={{ top: 2, leading: 2, bottom: 2, trailing: 2 }}
-      widgetBackground={{
-        style: surfaces.border,
-        shape: { type: "rect", cornerRadius: 26, style: "continuous" },
-      }}
-    >
-      {body}
-    </VStack>
-  )
+  return wrapWithBorderLayer({ child: body, surfaces, cornerRadius: 24, padding: 2 })
 }


### PR DESCRIPTION
## Summary
- refresh widget surface palette to support transparent overlays and reusable outline wrapping
- update fee/ring cards and layouts to consume shared surfaces for consistent borders and backgrounds
- soften carrier theme backgrounds to match lighter overlay styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947e484912883269247dc047e31b902)